### PR TITLE
Fix missing RuntimeIdentifier

### DIFF
--- a/Destinations/NBug.Destinations.AzureBlobStorage/NBug.Destinations.AzureBlobStorage.csproj
+++ b/Destinations/NBug.Destinations.AzureBlobStorage/NBug.Destinations.AzureBlobStorage.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>NBug.Destinations.AzureBlobStorage</RootNamespace>
     <AssemblyName>NBug.Destinations.AzureBlobStorage</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/Documentation/Documentation.csproj
+++ b/Documentation/Documentation.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Documentation</RootNamespace>
     <AssemblyName>Documentation</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>

--- a/Examples/NBug.Examples.Console/NBug.Examples.Console.csproj
+++ b/Examples/NBug.Examples.Console/NBug.Examples.Console.csproj
@@ -11,8 +11,7 @@
     <RootNamespace>NBug.Examples.Console</RootNamespace>
     <AssemblyName>NBug.Examples.Console</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>

--- a/Examples/NBug.Examples.WPF/NBug.Examples.WPF.csproj
+++ b/Examples/NBug.Examples.WPF/NBug.Examples.WPF.csproj
@@ -11,8 +11,7 @@
     <RootNamespace>NBug.Examples.WPF</RootNamespace>
     <AssemblyName>NBug.Examples.WPF</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/Examples/NBug.Examples.WinForms/NBug.Examples.WinForms.csproj
+++ b/Examples/NBug.Examples.WinForms/NBug.Examples.WinForms.csproj
@@ -11,8 +11,7 @@
     <RootNamespace>NBug.Examples.WinForms</RootNamespace>
     <AssemblyName>NBug.Examples.WinForms</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>

--- a/NBug.Configurator/NBug.Configurator.csproj
+++ b/NBug.Configurator/NBug.Configurator.csproj
@@ -11,8 +11,7 @@
     <RootNamespace>NBug.Configurator</RootNamespace>
     <AssemblyName>NBug.Configurator</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>

--- a/NBug.Tests/NBug.Tests.csproj
+++ b/NBug.Tests/NBug.Tests.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>NBug.Tests</RootNamespace>
     <AssemblyName>NBug.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/NBug/NBug.csproj
+++ b/NBug/NBug.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>NBug</RootNamespace>
     <AssemblyName>NBug</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>


### PR DESCRIPTION
It appears MSBuild 15.8 or 15.9 requires explicit RuntimeIdentifier=win.

Part of gitextensions/gitextensions#6497