### PR TITLE
NBug issue template: Add default text

### DIFF
--- a/NBug/Core/Util/ErrorReportMarkDownBodyBuilder.cs
+++ b/NBug/Core/Util/ErrorReportMarkDownBodyBuilder.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+﻿ // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GitHub.cs" company="Git Extensions">
 //   Copyright (c) 2019 Igor Velikorossov. Licensed under MIT license.
 // </copyright>
@@ -28,6 +28,8 @@ namespace NBug.Core.Util
             sb.AppendLine(@"<!--
     :warning: Review existing issues to see whether someone else has already reported your issue.
 -->
+
+:warning: The sections below must be filled in and this text must be removed or the issue will be closed.
 
 ## Current behaviour
 


### PR DESCRIPTION
As suggested in https://github.com/gitextensions/gitextensions/issues/6607#issuecomment-494683221
and https://github.com/gitextensions/NBug/pull/18

The intention is to have something the bot can close automatically without having the submitter or other users "offended".